### PR TITLE
doc: fix examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ https://user-images.githubusercontent.com/5759207/190852270-7aed2db9-dc08-4a9f-8
 
 # How to use:
 1. `pip install -r requirements.txt`.
-2. Download model from "Releases" tab.
+2. Download `model.pth` and `speakers.pth` from "Releases" tab.
 3. Launch as one-time command:  
 ```
 tts --text "Text for TTS" \
     --model_path path/to/model.pth \
     --config_path path/to/config.json \
+    --speaker_idx dmytro \
     --out_path folder/to/save/output.wav
 ```
 or alternatively launch web server using:


### PR DESCRIPTION
# Problem
The one-time snippet does not work as is and complains that the speaker is not defined 
```
 > initialization of speaker-embedding layers.
 > Text: Перевірка мікрофона
 > Text splitted to sentences.
['Перевірка мікрофона']
Traceback (most recent call last):
  File "/home/serg/.local/bin/tts", line 8, in <module>
    sys.exit(main())
  File "/home/serg/.local/lib/python3.8/site-packages/TTS/bin/synthesize.py", line 350, in main
    wav = synthesizer.tts(
  File "/home/serg/.local/lib/python3.8/site-packages/TTS/utils/synthesizer.py", line 228, in tts
    raise ValueError(
ValueError:  [!] Look like you use a multi-speaker model. You need to define either a `speaker_name` or a `speaker_wav` to use a multi-speaker model.
```
Also it `speakers.pth` should be downloaded.

# Fix
Just a few documentation changes:
- make instructions on what to download from Releases more precise
- add `--speaker_id` argument with one of the speakers